### PR TITLE
롯데마트 00/00 외 0/0 형식의 날짜 적용

### DIFF
--- a/custom_components/mart_holiday/sensor.py
+++ b/custom_components/mart_holiday/sensor.py
@@ -516,7 +516,7 @@ class LotteMartAPI:
             holidate = lmart['holiDate']
 
             # 00/00 처리
-            r = re.compile("\d{2}/\d{2}")
+            r = re.compile("\d{1,2}/\d{1,2}")
             rtn = r.findall(holidate)
 
             # 00월 00일 처리


### PR DESCRIPTION
롯데마트 판교점의 경우 아래와 같은 날짜 형식도 존재합니다.

5/9(일),5/23(일)
※ 사이트 : http://company.lottemart.com/bc/branch/main.do?menuCd=BM0201&SITELOC=DB001

롯데마트 판교점의 경우 오류가 발생하여 위와 같이 수정했는데 혹시 위와 같이 수정 했을 때 문제가 있을지 문의드립니다