### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/mart_holiday/sensor.py
+++ b/custom_components/mart_holiday/sensor.py
@@ -237,7 +237,7 @@ def Comm2Date(val):
     tmp = val.split("-")
 
     if len(tmp) > 1:
-        return datetime(year=int(tmp[0]), month=int(tmp[1]), day=int(tmp[2]))
+        return datetime(year=int(tmp[0]), month=int(tmp[1]), day=int(tmp[2]), hour=23, minute=59, second=59)
     else:
         return None
 


### PR DESCRIPTION
datetime 함수에 time 미설정시 0시 0분 0초로 정의되어, 휴무일이 YY-MM-DD-00:00:00이 되고, 이마트 휴무일과 현재일자가 같으면 '-'로 결과값이 리턴됨. 시간을 지정하여 오류 수정 제안.